### PR TITLE
Descriptor pools/heaps, descriptor sets / root signatures, buffer views

### DIFF
--- a/Samples/D3D12/Library/Library.cpp
+++ b/Samples/D3D12/Library/Library.cpp
@@ -42,6 +42,14 @@ int main()
 	const NK::UniquePtr<NK::IBuffer> buffer{ device->CreateBuffer(bufferDesc) };
 	logger->Log(NK::LOGGER_CHANNEL::INFO, NK::LOGGER_LAYER::APPLICATION, "Total memory allocated: " + NK::FormatUtils::GetSizeString(dynamic_cast<NK::TrackingAllocator*>(allocator)->GetTotalMemoryAllocated()) + "\n\n");
 
+	NK::BufferViewDesc bufferViewDesc{};
+	bufferViewDesc.type = NK::BUFFER_VIEW_TYPE::CONSTANT;
+	bufferViewDesc.offset = 0;
+	bufferViewDesc.size = bufferDesc.size;
+	const NK::ResourceIndex bufferViewIndex{ device->CreateBufferView(buffer.get(), bufferViewDesc) };
+	logger->Log(NK::LOGGER_CHANNEL::INFO, NK::LOGGER_LAYER::APPLICATION, "Buffer view index: " + std::to_string(bufferViewIndex) + "\n");
+	logger->Log(NK::LOGGER_CHANNEL::INFO, NK::LOGGER_LAYER::APPLICATION, "Total memory allocated: " + NK::FormatUtils::GetSizeString(dynamic_cast<NK::TrackingAllocator*>(allocator)->GetTotalMemoryAllocated()) + "\n\n");
+
 	NK::TextureDesc textureDesc{};
 	textureDesc.size = glm::ivec3(1920, 1080, 1);
 	textureDesc.arrayTexture = false;

--- a/Samples/Vulkan/Library/Library.cpp
+++ b/Samples/Vulkan/Library/Library.cpp
@@ -10,8 +10,6 @@
 #include "RHI/ICommandPool.h"
 #include "RHI/IDevice.h"
 
-#include <utility>
-
 
 
 int main()
@@ -43,6 +41,14 @@ int main()
 	bufferDesc.type = NK::MEMORY_TYPE::DEVICE;
 	bufferDesc.usage = NK::BUFFER_USAGE_FLAGS::UNIFORM_BUFFER_BIT;
 	const NK::UniquePtr<NK::IBuffer> buffer{ device->CreateBuffer(bufferDesc) };
+	logger->Log(NK::LOGGER_CHANNEL::INFO, NK::LOGGER_LAYER::APPLICATION, "Total memory allocated: " + NK::FormatUtils::GetSizeString(dynamic_cast<NK::TrackingAllocator*>(allocator)->GetTotalMemoryAllocated()) + "\n\n");
+
+	NK::BufferViewDesc bufferViewDesc{};
+	bufferViewDesc.type = NK::BUFFER_VIEW_TYPE::CONSTANT;
+	bufferViewDesc.offset = 0;
+	bufferViewDesc.size = bufferDesc.size;
+	const NK::ResourceIndex bufferViewIndex{ device->CreateBufferView(buffer.get(), bufferViewDesc) };
+	logger->Log(NK::LOGGER_CHANNEL::INFO, NK::LOGGER_LAYER::APPLICATION, "Buffer view index: " + std::to_string(bufferViewIndex) + "\n");
 	logger->Log(NK::LOGGER_CHANNEL::INFO, NK::LOGGER_LAYER::APPLICATION, "Total memory allocated: " + NK::FormatUtils::GetSizeString(dynamic_cast<NK::TrackingAllocator*>(allocator)->GetTotalMemoryAllocated()) + "\n\n");
 	
 	NK::TextureDesc textureDesc{};

--- a/src/Core/Memory/FreeListAllocator.cpp
+++ b/src/Core/Memory/FreeListAllocator.cpp
@@ -12,6 +12,13 @@ namespace NK
 			return index;
 		}
 
+		if (m_nextFreeIndex == m_maxActiveAllocations + 1)
+		{
+			//Max active allocations reached since next free index would be max active allocations + 1
+			//Return invalid index
+			return INVALID_INDEX;
+		}
+		
 		return m_nextFreeIndex++;
 	}
 

--- a/src/Core/Memory/FreeListAllocator.cpp
+++ b/src/Core/Memory/FreeListAllocator.cpp
@@ -1,0 +1,25 @@
+#include "FreeListAllocator.h"
+
+namespace NK
+{
+	
+	std::uint32_t FreeListAllocator::Allocate()
+	{
+		if (!m_freeList.empty())
+		{
+			const std::uint32_t index{ m_freeList.back() };
+			m_freeList.pop_back();
+			return index;
+		}
+
+		return m_nextFreeIndex++;
+	}
+
+
+
+	void FreeListAllocator::Free(std::uint32_t _val)
+	{
+		m_freeList.push_back(_val);
+	}
+
+}

--- a/src/Core/Memory/FreeListAllocator.h
+++ b/src/Core/Memory/FreeListAllocator.h
@@ -1,0 +1,21 @@
+#pragma once
+#include <cstdint>
+#include <vector>
+
+namespace NK
+{
+	class FreeListAllocator
+	{
+	public:
+		FreeListAllocator() = default;
+		~FreeListAllocator() = default;
+		
+		[[nodiscard]] std::uint32_t Allocate();
+		void Free(std::uint32_t _val);
+
+
+	private:
+		std::uint32_t m_nextFreeIndex{ 0 };
+		std::vector<std::uint32_t> m_freeList;
+	};
+}

--- a/src/Core/Memory/FreeListAllocator.h
+++ b/src/Core/Memory/FreeListAllocator.h
@@ -7,15 +7,22 @@ namespace NK
 	class FreeListAllocator
 	{
 	public:
-		FreeListAllocator() = default;
+		explicit FreeListAllocator(std::size_t _maxActiveAllocations)
+		: m_maxActiveAllocations(_maxActiveAllocations), m_nextFreeIndex(0) {}
+
+		FreeListAllocator() = delete;
+		
 		~FreeListAllocator() = default;
 		
 		[[nodiscard]] std::uint32_t Allocate();
 		void Free(std::uint32_t _val);
 
+		static constexpr std::size_t INVALID_INDEX{ UINT32_MAX };
+		
 
 	private:
-		std::uint32_t m_nextFreeIndex{ 0 };
+		std::size_t m_maxActiveAllocations;
+		std::uint32_t m_nextFreeIndex;
 		std::vector<std::uint32_t> m_freeList;
 	};
 }

--- a/src/RHI-D3D12/D3D12Buffer.cpp
+++ b/src/RHI-D3D12/D3D12Buffer.cpp
@@ -42,7 +42,7 @@ namespace NK
 		bufferDesc.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
 		bufferDesc.Flags = GetCreationFlags();
 
-		HRESULT result{ dynamic_cast<D3D12Device&>(m_device).GetDevice().Get()->CreateCommittedResource(&heapProps, D3D12_HEAP_FLAG_NONE, &bufferDesc, GetInitialState(), nullptr, IID_PPV_ARGS(&m_buffer)) };
+		HRESULT result{ dynamic_cast<D3D12Device&>(m_device).GetDevice()->CreateCommittedResource(&heapProps, D3D12_HEAP_FLAG_NONE, &bufferDesc, GetInitialState(), nullptr, IID_PPV_ARGS(&m_buffer)) };
 	}
 	
 	

--- a/src/RHI-D3D12/D3D12Buffer.h
+++ b/src/RHI-D3D12/D3D12Buffer.h
@@ -13,6 +13,9 @@ namespace NK
 		virtual void* Map() override;
 		virtual void Unmap() override;
 
+		//D3D12 internal API (for use by other RHI-D3D12 classes)
+		[[nodiscard]] inline ID3D12Resource* GetBuffer() const { return m_buffer.Get(); }
+
 
 	private:
 		[[nodiscard]] D3D12_RESOURCE_FLAGS GetCreationFlags() const;

--- a/src/RHI-D3D12/D3D12CommandBuffer.cpp
+++ b/src/RHI-D3D12/D3D12CommandBuffer.cpp
@@ -23,7 +23,7 @@ namespace NK
 		case COMMAND_POOL_TYPE::COMPUTE:	type = D3D12_COMMAND_LIST_TYPE_COMPUTE;	break;
 		case COMMAND_POOL_TYPE::TRANSFER:	type = D3D12_COMMAND_LIST_TYPE_COPY;	break;
 		}
-		const HRESULT result{ dynamic_cast<D3D12Device&>(m_device).GetDevice()->CreateCommandList(0, type, dynamic_cast<D3D12CommandPool&>(m_pool).GetCommandPool().Get(), nullptr, IID_PPV_ARGS(&m_buffer)) };
+		const HRESULT result{ dynamic_cast<D3D12Device&>(m_device).GetDevice()->CreateCommandList(0, type, dynamic_cast<D3D12CommandPool&>(m_pool).GetCommandPool(), nullptr, IID_PPV_ARGS(&m_buffer)) };
 
 		if (SUCCEEDED(result))
 		{

--- a/src/RHI-D3D12/D3D12CommandPool.h
+++ b/src/RHI-D3D12/D3D12CommandPool.h
@@ -16,7 +16,7 @@ namespace NK
 		virtual void Reset(COMMAND_POOL_RESET_FLAGS _type) override;
 
 		//D3D12 internal API (for use by other RHI-D3D12 classes)
-		[[nodiscard]] inline Microsoft::WRL::ComPtr<ID3D12CommandAllocator> GetCommandPool() const { return m_pool; }
+		[[nodiscard]] inline ID3D12CommandAllocator* GetCommandPool() const { return m_pool.Get(); }
 
 
 	private:

--- a/src/RHI-D3D12/D3D12Device.h
+++ b/src/RHI-D3D12/D3D12Device.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <RHI/IDevice.h>
 #include <RHI/ICommandPool.h>
+
 #include <dxgi1_6.h>
 #include <d3d12.h>
 #include <wrl.h>
@@ -17,17 +18,18 @@ namespace NK
 
 		//IDevice interface implementation
 		[[nodiscard]] virtual UniquePtr<IBuffer> CreateBuffer(const BufferDesc& _desc) override;
+		[[nodiscard]] virtual ResourceIndex CreateBufferView(IBuffer* _buffer, const BufferViewDesc& _desc) override;
 		[[nodiscard]] virtual UniquePtr<ITexture> CreateTexture(const TextureDesc& _desc) override;
 		[[nodiscard]] virtual UniquePtr<ICommandPool> CreateCommandPool(const CommandPoolDesc& _desc) override;
 		//[[nodiscard]] virtual UniquePtr<ISurface> CreateSurface(const Window* _window) override;
 
 		//D3D12 internal API (for use by other RHI-D3D12 classes)
-		[[nodiscard]] inline Microsoft::WRL::ComPtr<IDXGIFactory> GetFactory() const { return m_factory; }
-		[[nodiscard]] inline Microsoft::WRL::ComPtr<IDXGIAdapter> GetAdapter() const { return m_adapter; }
-		[[nodiscard]] inline Microsoft::WRL::ComPtr<ID3D12Device> GetDevice() const { return m_device; }
-		[[nodiscard]] inline Microsoft::WRL::ComPtr<ID3D12CommandQueue> GetGraphicsQueue() const { return m_graphicsQueue; }
-		[[nodiscard]] inline Microsoft::WRL::ComPtr<ID3D12CommandQueue> GetComputeQueue() const { return m_computeQueue; }
-		[[nodiscard]] inline Microsoft::WRL::ComPtr<ID3D12CommandQueue> GetTransferQueue() const { return m_transferQueue; }
+		[[nodiscard]] inline IDXGIFactory* GetFactory() const { return m_factory.Get(); }
+		[[nodiscard]] inline IDXGIAdapter* GetAdapter() const { return m_adapter.Get(); }
+		[[nodiscard]] inline ID3D12Device* GetDevice()  const { return m_device.Get();  }
+		[[nodiscard]] inline ID3D12CommandQueue* GetGraphicsQueue() const { return m_graphicsQueue.Get(); }
+		[[nodiscard]] inline ID3D12CommandQueue* GetComputeQueue()  const { return m_computeQueue.Get(); }
+		[[nodiscard]] inline ID3D12CommandQueue* GetTransferQueue() const { return m_transferQueue.Get(); }
 
 
 	private:
@@ -37,9 +39,12 @@ namespace NK
 		void SelectAdapter();
 		void CreateDevice();
 		void CreateCommandQueues();
+		void CreateDescriptorHeaps();
+		void CreateRootSignature();
 
 
 		const D3D_FEATURE_LEVEL m_featureLevel{ D3D_FEATURE_LEVEL_12_0 };
+
 
 		//D3D12 handles
 		Microsoft::WRL::ComPtr<IDXGIFactory4> m_factory;
@@ -49,6 +54,13 @@ namespace NK
 		Microsoft::WRL::ComPtr<ID3D12CommandQueue> m_graphicsQueue;
 		Microsoft::WRL::ComPtr<ID3D12CommandQueue> m_computeQueue;
 		Microsoft::WRL::ComPtr<ID3D12CommandQueue> m_transferQueue;
+
+		Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> m_resourceDescriptorHeap;
+		UINT m_resourceDescriptorSize;
+		Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> m_samplerDescriptorHeap;
+		UINT m_samplerDescriptorSize;
+		Microsoft::WRL::ComPtr<ID3D12RootSignature> m_rootSig;
+
 
 
 		bool m_enableDebugLayer{ true };

--- a/src/RHI-D3D12/D3D12Texture.cpp
+++ b/src/RHI-D3D12/D3D12Texture.cpp
@@ -75,7 +75,7 @@ namespace NK
 		textureDesc.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
 		textureDesc.Flags = GetCreationFlags();
 
-		HRESULT result{ dynamic_cast<D3D12Device&>(m_device).GetDevice().Get()->CreateCommittedResource(&heapProps, D3D12_HEAP_FLAG_NONE, &textureDesc, GetInitialState(), nullptr, IID_PPV_ARGS(&m_texture)) };
+		HRESULT result{ dynamic_cast<D3D12Device&>(m_device).GetDevice()->CreateCommittedResource(&heapProps, D3D12_HEAP_FLAG_NONE, &textureDesc, GetInitialState(), nullptr, IID_PPV_ARGS(&m_texture)) };
 
 		if (SUCCEEDED(result))
 		{

--- a/src/RHI-Vulkan/VulkanBuffer.h
+++ b/src/RHI-Vulkan/VulkanBuffer.h
@@ -12,11 +12,14 @@ namespace NK
 		virtual void* Map() override;
 		virtual void Unmap() override;
 
+		//Vulkan internal API (for use by other RHI-Vulkan classes)
+		[[nodiscard]] inline VkBuffer GetBuffer() const { return m_buffer; }
+
 
 	private:
 		[[nodiscard]] VkBufferUsageFlags GetVulkanUsageFlags() const;
-		
-		
+
+
 		VkBuffer m_buffer{ VK_NULL_HANDLE };
 		VkDeviceMemory m_memory{ VK_NULL_HANDLE };
 	};

--- a/src/RHI-Vulkan/VulkanDevice.cpp
+++ b/src/RHI-Vulkan/VulkanDevice.cpp
@@ -15,14 +15,10 @@
 #include "GLFW/glfw3.h"
 
 namespace NK
-{
-	constexpr std::uint32_t MAX_BINDLESS_RESOURCES{ 65536 };
-	constexpr std::uint32_t MAX_BINDLESS_SAMPLERS{ 2048 };
-	
-	
+{		
 	
 	VulkanDevice::VulkanDevice(ILogger& _logger, IAllocator& _allocator)
-	: IDevice(_logger, _allocator), m_resourceIndexAllocator(NK_NEW(FreeListAllocator, MAX_BINDLESS_RESOURCES))
+	: IDevice(_logger, _allocator)
 	{
 		m_logger.Indent();
 		m_logger.Log(LOGGER_CHANNEL::HEADING, LOGGER_LAYER::DEVICE, "Initialising VulkanDevice\n");

--- a/src/RHI-Vulkan/VulkanDevice.h
+++ b/src/RHI-Vulkan/VulkanDevice.h
@@ -7,9 +7,6 @@
 #include <RHI/IDevice.h>
 #include <vulkan/vulkan.h>
 
-#include "Core/Memory/FreeListAllocator.h"
-
-
 
 namespace NK
 {
@@ -81,7 +78,6 @@ namespace NK
 		VkDescriptorPool m_descriptorPool{ VK_NULL_HANDLE };
 		VkDescriptorSetLayout m_descriptorSetLayout{ VK_NULL_HANDLE };
 		VkDescriptorSet m_descriptorSet{ VK_NULL_HANDLE };
-		UniquePtr<FreeListAllocator> m_resourceIndexAllocator;
 
 
 		bool m_enableInstanceValidationLayers = true;

--- a/src/RHI-Vulkan/VulkanDevice.h
+++ b/src/RHI-Vulkan/VulkanDevice.h
@@ -7,6 +7,8 @@
 #include <RHI/IDevice.h>
 #include <vulkan/vulkan.h>
 
+#include "Core/Memory/FreeListAllocator.h"
+
 
 
 namespace NK
@@ -19,7 +21,7 @@ namespace NK
 
 		//IDevice interface implementation
 		[[nodiscard]] virtual UniquePtr<IBuffer> CreateBuffer(const BufferDesc& _desc) override;
-		[[nodiscard]] virtual ResourceIndex CreateBufferView(const BufferViewDesc& _desc) override;
+		[[nodiscard]] virtual ResourceIndex CreateBufferView(IBuffer* _buffer, const BufferViewDesc& _desc) override;
 		[[nodiscard]] virtual UniquePtr<ITexture> CreateTexture(const TextureDesc& _desc) override;
 		[[nodiscard]] virtual UniquePtr<ICommandPool> CreateCommandPool(const CommandPoolDesc& _desc) override;
 //		[[nodiscard]] virtual UniquePtr<ISurface> CreateSurface(const Window* _window) override;
@@ -31,6 +33,7 @@ namespace NK
 		[[nodiscard]] inline std::uint32_t GetGraphicsQueueFamilyIndex() const { return m_graphicsQueueFamilyIndex; }
 		[[nodiscard]] inline std::uint32_t GetComputeQueueFamilyIndex() const { return m_computeQueueFamilyIndex; }
 		[[nodiscard]] inline std::uint32_t GetTransferQueueFamilyIndex() const { return m_transferQueueFamilyIndex; }
+
 
 	private:
 		//Init sub-methods
@@ -73,11 +76,12 @@ namespace NK
 			VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, //uav read
 			VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, //uav read-write
 		};
-		VkMutableDescriptorTypeListEXT m_mutableResourceTypeList;
-		VkMutableDescriptorTypeCreateInfoEXT m_mutableResourceTypeInfo;
+		VkMutableDescriptorTypeListEXT m_mutableResourceTypeList{};
+		VkMutableDescriptorTypeCreateInfoEXT m_mutableResourceTypeInfo{};
 		VkDescriptorPool m_descriptorPool{ VK_NULL_HANDLE };
 		VkDescriptorSetLayout m_descriptorSetLayout{ VK_NULL_HANDLE };
 		VkDescriptorSet m_descriptorSet{ VK_NULL_HANDLE };
+		UniquePtr<FreeListAllocator> m_resourceIndexAllocator;
 
 
 		bool m_enableInstanceValidationLayers = true;

--- a/src/RHI-Vulkan/VulkanDevice.h
+++ b/src/RHI-Vulkan/VulkanDevice.h
@@ -19,6 +19,7 @@ namespace NK
 
 		//IDevice interface implementation
 		[[nodiscard]] virtual UniquePtr<IBuffer> CreateBuffer(const BufferDesc& _desc) override;
+		[[nodiscard]] virtual ResourceIndex CreateBufferView(const BufferViewDesc& _desc) override;
 		[[nodiscard]] virtual UniquePtr<ITexture> CreateTexture(const TextureDesc& _desc) override;
 		[[nodiscard]] virtual UniquePtr<ICommandPool> CreateCommandPool(const CommandPoolDesc& _desc) override;
 //		[[nodiscard]] virtual UniquePtr<ISurface> CreateSurface(const Window* _window) override;
@@ -37,9 +38,13 @@ namespace NK
 		void SetupDebugMessenger();
 		void SelectPhysicalDevice();
 		void CreateLogicalDevice();
+		void CreateMutableResourceType();
+		void CreateDescriptorPool();
+		void CreateDescriptorSetLayout();
+		void CreateDescriptorSet();
 
 		//Utility functions
-		[[nodiscard]] bool ValidationLayerSupported() const;
+		[[nodiscard]] bool ValidationLayersSupported() const;
 		[[nodiscard]] std::vector<const char*> GetRequiredExtensions() const;
 		void PopulateDebugMessengerCreateInfo(VkDebugUtilsMessengerCreateInfoEXT& _info) const;
 		static VKAPI_ATTR VkBool32 VKAPI_CALL DebugCallback(VkDebugUtilsMessageSeverityFlagBitsEXT _messageSeverity, VkDebugUtilsMessageTypeFlagsEXT _messageType, const VkDebugUtilsMessengerCallbackDataEXT* _pCallbackData, void* _pUserData);
@@ -61,10 +66,23 @@ namespace NK
 		VkQueue m_transferQueue{ VK_NULL_HANDLE };
 		std::uint32_t m_transferQueueFamilyIndex{ UINT32_MAX };
 
+		inline static constexpr std::array<VkDescriptorType, 4> m_resourceTypes
+		{
+			VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, //cbv
+			VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, //srv
+			VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, //uav read
+			VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, //uav read-write
+		};
+		VkMutableDescriptorTypeListEXT m_mutableResourceTypeList;
+		VkMutableDescriptorTypeCreateInfoEXT m_mutableResourceTypeInfo;
+		VkDescriptorPool m_descriptorPool{ VK_NULL_HANDLE };
+		VkDescriptorSetLayout m_descriptorSetLayout{ VK_NULL_HANDLE };
+		VkDescriptorSet m_descriptorSet{ VK_NULL_HANDLE };
+
 
 		bool m_enableInstanceValidationLayers = true;
 		const std::array<const char*, 1> m_instanceValidationLayers{ "VK_LAYER_KHRONOS_validation" };
 		const std::array<const char*, 1> m_requiredInstanceExtensions{ VK_KHR_SURFACE_EXTENSION_NAME };
-		const std::array<const char*, 2> requiredDeviceExtensions{ VK_KHR_SWAPCHAIN_EXTENSION_NAME, "VK_EXT_mesh_shader" };
+		const std::array<const char*, 3> requiredDeviceExtensions{ VK_KHR_SWAPCHAIN_EXTENSION_NAME, "VK_EXT_mesh_shader", "VK_EXT_mutable_descriptor_type" };
 	};
 }

--- a/src/RHI/IDevice.h
+++ b/src/RHI/IDevice.h
@@ -1,11 +1,11 @@
 #pragma once
-#include "IDevice.h"
 #include "Core/Debug/ILogger.h"
 #include "Core/Memory/Allocation.h"
 #include "Core/Memory/IAllocator.h"
 
 namespace NK
 {
+	//Forward declarations
 	class IBuffer;
 	struct BufferDesc;
 
@@ -17,22 +17,41 @@ namespace NK
 
 	class Window;
 	class ISurface;
+
+	
+	typedef std::uint32_t ResourceIndex;
+
+
+	enum class BUFFER_VIEW_TYPE
+	{
+		CONSTANT,
+		SHADER_RESOURCE,
+		UNORDERED_ACCESS,
+	};
+	
+	struct BufferViewDesc
+	{
+		BUFFER_VIEW_TYPE type;
+		std::uint64_t offset; //Offset from start of IBuffer in bytes (must be aligned to hardware specific requirements)
+		std::uint64_t size; //Size of view in bytes
+	};
 }
 
 
 
 namespace NK
 {
-
+	
 	class IDevice
 	{
 	public:
 		virtual ~IDevice() = default;
 
 		[[nodiscard]] virtual UniquePtr<IBuffer> CreateBuffer(const BufferDesc& _desc) = 0;
+		[[nodiscard]] virtual ResourceIndex CreateBufferView(const BufferViewDesc& _desc) = 0;
 		[[nodiscard]] virtual UniquePtr<ITexture> CreateTexture(const TextureDesc& _desc) = 0;
 		[[nodiscard]] virtual UniquePtr<ICommandPool> CreateCommandPool(const CommandPoolDesc& _desc) = 0;
-//		[[nodiscard]] virtual UniquePtr<ISurface> CreateSurface(const Window* _window) = 0;
+		//[[nodiscard]] virtual UniquePtr<ISurface> CreateSurface(const Window* _window) = 0;
 
 
 	protected:
@@ -42,5 +61,4 @@ namespace NK
 		ILogger& m_logger;
 		IAllocator& m_allocator;
 	};
-
 }

--- a/src/RHI/IDevice.h
+++ b/src/RHI/IDevice.h
@@ -48,7 +48,7 @@ namespace NK
 		virtual ~IDevice() = default;
 
 		[[nodiscard]] virtual UniquePtr<IBuffer> CreateBuffer(const BufferDesc& _desc) = 0;
-		[[nodiscard]] virtual ResourceIndex CreateBufferView(const BufferViewDesc& _desc) = 0;
+		[[nodiscard]] virtual ResourceIndex CreateBufferView(IBuffer* _buffer, const BufferViewDesc& _desc) = 0;
 		[[nodiscard]] virtual UniquePtr<ITexture> CreateTexture(const TextureDesc& _desc) = 0;
 		[[nodiscard]] virtual UniquePtr<ICommandPool> CreateCommandPool(const CommandPoolDesc& _desc) = 0;
 		//[[nodiscard]] virtual UniquePtr<ISurface> CreateSurface(const Window* _window) = 0;

--- a/src/RHI/IDevice.h
+++ b/src/RHI/IDevice.h
@@ -2,6 +2,8 @@
 #include "Core/Debug/ILogger.h"
 #include "Core/Memory/Allocation.h"
 #include "Core/Memory/IAllocator.h"
+#include "Core/Memory/FreeListAllocator.h"
+
 
 namespace NK
 {
@@ -18,7 +20,9 @@ namespace NK
 	class Window;
 	class ISurface;
 
-	
+
+	constexpr std::uint32_t MAX_BINDLESS_RESOURCES{ 65536 };
+	constexpr std::uint32_t MAX_BINDLESS_SAMPLERS{ 2048 };
 	typedef std::uint32_t ResourceIndex;
 
 
@@ -41,7 +45,6 @@ namespace NK
 
 namespace NK
 {
-	
 	class IDevice
 	{
 	public:
@@ -55,10 +58,13 @@ namespace NK
 
 
 	protected:
-		explicit IDevice(ILogger& _logger, IAllocator& _allocator) : m_logger(_logger), m_allocator(_allocator) {}
+		explicit IDevice(ILogger& _logger, IAllocator& _allocator)
+		: m_logger(_logger), m_allocator(_allocator), m_resourceIndexAllocator(NK_NEW(FreeListAllocator, MAX_BINDLESS_RESOURCES)) {}
 
 		//Dependency injections
 		ILogger& m_logger;
 		IAllocator& m_allocator;
+
+		UniquePtr<FreeListAllocator> m_resourceIndexAllocator;
 	};
 }


### PR DESCRIPTION
Added:
- Descriptor pool, descriptor set, and buffer view creation to VulkanDevice for resource creation
- Descriptor heaps, root signatures, and buffer view creation to D3D12Device for resource creation

Both library samples updated - tested and working on Linux and Windows respectively.